### PR TITLE
Typography and copy changes

### DIFF
--- a/x-pack/plugins/canvas/public/components/keyboard_shortcuts_doc/keyboard_shortcuts_doc.js
+++ b/x-pack/plugins/canvas/public/components/keyboard_shortcuts_doc/keyboard_shortcuts_doc.js
@@ -14,6 +14,7 @@ import {
   EuiHorizontalRule,
   EuiCode,
   EuiSpacer,
+  EuiTitle,
 } from '@elastic/eui';
 import { keymap } from '../../lib/keymap';
 import { getClientPlatform } from '../../lib/get_client_platform';
@@ -54,19 +55,24 @@ const getDescriptionListItems = shortcuts =>
 export const KeyboardShortcutsDoc = props => (
   <EuiFlyout closeButtonAriaLabel="Closes keyboard shortcuts reference" size="s" {...props}>
     <EuiFlyoutHeader hasBorder>
-      <h2>Keyboard Shortcuts</h2>
+      <EuiTitle size="s">
+        <h2>Keyboard Shortcuts</h2>
+      </EuiTitle>
     </EuiFlyoutHeader>
     <EuiFlyoutBody>
       {Object.values(keymap).map(namespace => {
         const { displayName, ...shortcuts } = namespace;
         return (
           <div key={getId('shortcuts')} className="canvasKeyboardShortcut">
-            <h3>{displayName}</h3>
+            <EuiTitle size="xs">
+              <h4>{displayName}</h4>
+            </EuiTitle>
             <EuiHorizontalRule margin="s" />
             <EuiDescriptionList
               textStyle="reverse"
               type="column"
               listItems={getDescriptionListItems(shortcuts)}
+              compressed
             />
             <EuiSpacer />
           </div>

--- a/x-pack/plugins/canvas/public/lib/keymap.js
+++ b/x-pack/plugins/canvas/public/lib/keymap.js
@@ -45,46 +45,46 @@ const nextPageShortcut = { ...getAltShortcuts(']'), help: 'Go to next page' };
 export const keymap = {
   ELEMENT: {
     displayName: 'Element controls',
-    COPY: { ...getCtrlShortcuts('c'), help: 'Copy elements' },
-    CLONE: { ...getCtrlShortcuts('d'), help: 'Clone elements' },
-    CUT: { ...getCtrlShortcuts('x'), help: 'Cut elements' },
+    COPY: { ...getCtrlShortcuts('c'), help: 'Copy' },
+    CLONE: { ...getCtrlShortcuts('d'), help: 'Clone' },
+    CUT: { ...getCtrlShortcuts('x'), help: 'Cut' },
     PASTE: { ...getCtrlShortcuts('v'), help: 'Paste' },
     DELETE: {
       osx: ['backspace'],
       windows: ['del', 'backspace'],
       linux: ['del', 'backspace'],
       other: ['del', 'backspace'],
-      help: 'Delete elements',
+      help: 'Delete',
     },
     BRING_FORWARD: {
       ...getCtrlShortcuts('up'),
-      help: 'Send element forward one layer',
-    },
-    SEND_BACKWARD: {
-      ...getCtrlShortcuts('down'),
-      help: 'Send element back one layer',
+      help: 'Send forward',
     },
     BRING_TO_FRONT: {
       ...getCtrlShortcuts('shift+up'),
-      help: 'Send element to front',
+      help: 'Send to front',
+    },
+    SEND_BACKWARD: {
+      ...getCtrlShortcuts('down'),
+      help: 'Send backward',
     },
     SEND_TO_BACK: {
       ...getCtrlShortcuts('shift+down'),
-      help: 'Send element to back',
+      help: 'Send to back',
     },
     GROUP: {
       osx: ['g'],
       windows: ['g'],
       linux: ['g'],
       other: ['g'],
-      help: 'Group elements',
+      help: 'Group',
     },
     UNGROUP: {
       osx: ['u'],
       windows: ['u'],
       linux: ['u'],
       other: ['u'],
-      help: 'Ungroup elements',
+      help: 'Ungroup',
     },
   },
   EDITOR: {


### PR DESCRIPTION
- Uses`EuiTitle`
- Adjust titles sizes
-  Use `compressed` description list for smaller font sizes to minimize wrapping
-  Re-order move-to-front shortcut to a more common order
-  Remove the word _elements_ since it was repetitive and the section title alreadys states that these are _Element shortcuts_