### PR TITLE
Style the expression editor controls

### DIFF
--- a/x-pack/plugins/canvas/public/components/autocomplete/autocomplete.js
+++ b/x-pack/plugins/canvas/public/components/autocomplete/autocomplete.js
@@ -254,7 +254,9 @@ export class Autocomplete extends React.Component {
         ) : (
           ''
         )}
-        <div onMouseDown={this.onMouseDown}>{this.props.children}</div>
+        <div className="canvasAutocomplete--inner" onMouseDown={this.onMouseDown}>
+          {this.props.children}
+        </div>
       </div>
     );
   }

--- a/x-pack/plugins/canvas/public/components/expression/expression.js
+++ b/x-pack/plugins/canvas/public/components/expression/expression.js
@@ -10,11 +10,13 @@ import {
   EuiPanel,
   EuiButton,
   EuiButtonEmpty,
+  EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
   EuiSwitch,
   EuiSelect,
   EuiRange,
+  EuiToolTip,
 } from '@elastic/eui';
 import { ExpressionInput } from '../expression_input';
 import { fontSizes } from '../text_style_picker/font_sizes';
@@ -49,7 +51,23 @@ export const Expression = ({
         onChange={updateValue}
         isAutocompleteEnabled={isAutocompleteEnabled}
       />
-      <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" gutterSize="s">
+      <div className="canvasExpression--controls">
+        <EuiToolTip content={isCompact ? 'Maximize' : 'Minimize'}>
+          <EuiButtonIcon
+            size="s"
+            onClick={toggleCompactView}
+            iconType="expand"
+            color="subdued"
+            aria-label="Toggle expression window height"
+          />
+        </EuiToolTip>
+      </div>
+      <EuiFlexGroup
+        className="canvasExpression--settings"
+        justifyContent="spaceBetween"
+        alignItems="center"
+        gutterSize="l"
+      >
         <EuiFlexItem grow={false}>
           <EuiSwitch
             id="autocompleteOptIn"
@@ -91,24 +109,27 @@ export const Expression = ({
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiButtonEmpty onClick={toggleCompactView} iconType="expand">
-            {isCompact ? 'expand' : 'shrink'}
-          </EuiButtonEmpty>
-        </EuiFlexItem>
         <EuiFlexItem>
           <EuiFlexGroup justifyContent="flexEnd" gutterSize="s">
-            <EuiButtonEmpty size="s" color={formState.dirty ? 'danger' : 'primary'} onClick={done}>
-              {formState.dirty ? 'Cancel' : 'Close'}
-            </EuiButtonEmpty>
-            <EuiButton
-              fill
-              disabled={!!error}
-              onClick={() => setExpression(formState.expression)}
-              size="s"
-            >
-              Run
-            </EuiButton>
+            <EuiFlexItem grow={false}>
+              <EuiButtonEmpty
+                size="s"
+                color={formState.dirty ? 'danger' : 'primary'}
+                onClick={done}
+              >
+                {formState.dirty ? 'Cancel' : 'Close'}
+              </EuiButtonEmpty>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiButton
+                fill
+                disabled={!!error}
+                onClick={() => setExpression(formState.expression)}
+                size="s"
+              >
+                Run
+              </EuiButton>
+            </EuiFlexItem>
           </EuiFlexGroup>
         </EuiFlexItem>
       </EuiFlexGroup>

--- a/x-pack/plugins/canvas/public/components/expression/expression.scss
+++ b/x-pack/plugins/canvas/public/components/expression/expression.scss
@@ -2,6 +2,48 @@
   max-height: 400px;
 }
 
+.canvasExpression--controls {
+  position: absolute;
+  right: $euiSizeXL;
+  top: $euiSizeL;
+}
+
 .canvasExpression--fullSize {
-  height: 100vh - 144px;
+  height: calc(100vh - 200px); // space for global nav and autocomplete popup
+  display: flex;
+  flex-direction: column;
+
+  .expressionInput {
+    flex-grow: 1;
+  }
+
+  .expressionInput--inner {
+    height: 100%;
+  }
+
+  .canvasExpression--settings {
+    flex-grow: 0;
+  }
+
+  .canvasTextArea--code {
+    height: 100%;
+    padding-right: $euiSizeXXL;
+  }
+
+  .autocomplete {
+    flex-grow: 1;
+
+    .canvasAutocomplete--inner {
+      height: 100%;
+    }
+  }
+
+  .autocompletePopup {
+    top: -102px;
+    height: 100px;
+  }
+
+  .autocompleteItems, .autocompleteReference {
+    height: 98px;
+  }
 }

--- a/x-pack/plugins/canvas/public/components/expression_input/expression_input.js
+++ b/x-pack/plugins/canvas/public/components/expression_input/expression_input.js
@@ -162,7 +162,13 @@ export class ExpressionInput extends React.Component {
       : 'This is the coded expression that backs this element. You better know what you are doing here.';
     return (
       <div className="expressionInput">
-        <EuiFormRow fullWidth isInvalid={Boolean(error)} error={error} helpText={helpText}>
+        <EuiFormRow
+          className="expressionInput--inner"
+          fullWidth
+          isInvalid={Boolean(error)}
+          error={error}
+          helpText={helpText}
+        >
           {isAutocompleteEnabled ? (
             <Autocomplete
               header={this.getHeader()}
@@ -177,7 +183,8 @@ export class ExpressionInput extends React.Component {
                 onChange={this.onChange}
                 inputRef={ref => (this.ref = ref)}
                 spellCheck="false"
-                style={{ fontSize: `${fontSize}px`, resize: 'vertical' }}
+                style={{ fontSize: `${fontSize}px` }}
+                resize="none"
               />
             </Autocomplete>
           ) : (
@@ -188,6 +195,8 @@ export class ExpressionInput extends React.Component {
               onChange={this.onChange}
               inputRef={ref => (this.ref = ref)}
               spellCheck="false"
+              style={{ fontSize: `${fontSize}px` }}
+              resize="none"
             />
           )}
         </EuiFormRow>


### PR DESCRIPTION
## Summary

Adds some style changes for the maximize/minimize feature:
- places an icon button in the upper right corder of the expression editor window
- re-orders the other expression editor controls
- sets full size height for expression editor, leaving space for autocomplete and global nav

![exp-minmax](https://user-images.githubusercontent.com/446285/53759962-298b1a80-3e87-11e9-92eb-30f3149def09.gif)
