### PR TITLE
Define interface sections

### DIFF
--- a/x-pack/plugins/canvas/public/apps/workpad/workpad_app/workpad_app.scss
+++ b/x-pack/plugins/canvas/public/apps/workpad/workpad_app/workpad_app.scss
@@ -30,8 +30,10 @@ $canvasLayoutFontSize: $euiFontSizeS;
 .canvasLayout__stageHeader {
   flex-grow: 0;
   flex-basis: auto;
-  padding: $euiSizeM $euiSize $euiSizeS $euiSize;
+  padding: ($euiSizeXS +1px) $euiSize $euiSizeXS $euiSize;
   font-size: $canvasLayoutFontSize;
+  border-bottom: $euiBorderThin;
+  background: $euiColorLightestShade;
 }
 
 .canvasLayout__stageContent {
@@ -60,6 +62,7 @@ $canvasLayoutFontSize: $euiFontSizeS;
   background: $euiColorLightestShade;
   display: flex;
   position: relative;
+  border-left: $euiBorderThin;
 
   .euiPanel {
     margin-bottom: $euiSizeS;

--- a/x-pack/plugins/canvas/public/components/sidebar_header/sidebar_header.scss
+++ b/x-pack/plugins/canvas/public/components/sidebar_header/sidebar_header.scss
@@ -1,5 +1,5 @@
 .canvasLayout__sidebarHeader {
-  padding: $euiSizeS 0;
+  padding: ($euiSizeXS * .5) 0;
 }
 
 .canvasContextMenu--topBorder {


### PR DESCRIPTION
## Summary

Adds borders to top and side sections so that page appears to go under those sections. Currently, it appears to go through the top menu as you scroll and zoom as there is no delineation.

<img width="1438" alt="Screenshot 2019-06-13 17 15 34" src="https://user-images.githubusercontent.com/446285/59470896-e08c2000-8dfe-11e9-9ce8-afe06e450222.png">
