### PR TITLE
Set height on Canvas workarea header

### DIFF
--- a/x-pack/legacy/plugins/canvas/public/apps/workpad/workpad_app/workpad_app.scss
+++ b/x-pack/legacy/plugins/canvas/public/apps/workpad/workpad_app/workpad_app.scss
@@ -37,6 +37,10 @@ $canvasLayoutFontSize: $euiFontSizeS;
   user-select: none;
 }
 
+.canvasLayout__stageHeaderInner {
+  height: ($euiSizeL * 2);
+}
+
 .canvasLayout__stageContent {
   flex-grow: 1;
   flex-basis: 0%;

--- a/x-pack/legacy/plugins/canvas/public/components/workpad_header/workpad_header.js
+++ b/x-pack/legacy/plugins/canvas/public/components/workpad_header/workpad_header.js
@@ -103,7 +103,12 @@ export class WorkpadHeader extends React.PureComponent {
     return (
       <div>
         {isModalVisible ? this._elementAdd() : null}
-        <EuiFlexGroup gutterSize="s" alignItems="center" justifyContent="spaceBetween">
+        <EuiFlexGroup
+          gutterSize="s"
+          alignItems="center"
+          justifyContent="spaceBetween"
+          className="canvasLayout__stageHeaderInner"
+        >
           <EuiFlexItem grow={false}>
             <EuiFlexGroup alignItems="center" gutterSize="xs">
               <EuiFlexItem grow={false}>


### PR DESCRIPTION
Set height on workarea header so that it's consistent between edit and read-only mode.