### PR TITLE
Top menu design tweaks

### DIFF
--- a/x-pack/legacy/plugins/canvas/public/apps/workpad/workpad_app/workpad_app.scss
+++ b/x-pack/legacy/plugins/canvas/public/apps/workpad/workpad_app/workpad_app.scss
@@ -31,7 +31,7 @@ $canvasLayoutFontSize: $euiFontSizeS;
 .canvasLayout__stageHeader {
   flex-grow: 0;
   flex-basis: auto;
-  padding: ($euiSizeXS + 1px) $euiSize $euiSizeXS;
+  padding: 1px $euiSize 0;
   font-size: $canvasLayoutFontSize;
   border-bottom: $euiBorderThin;
   background: $euiColorLightestShade;

--- a/x-pack/legacy/plugins/canvas/public/components/workpad_header/control_settings/control_settings.tsx
+++ b/x-pack/legacy/plugins/canvas/public/components/workpad_header/control_settings/control_settings.tsx
@@ -39,7 +39,7 @@ export const ControlSettings = ({
   };
 
   const popoverButton = (handleClick: MouseEventHandler<HTMLButtonElement>) => (
-    <EuiButtonEmpty size="s" aria-label={strings.getButtonLabel()} onClick={handleClick}>
+    <EuiButtonEmpty size="xs" aria-label={strings.getButtonLabel()} onClick={handleClick}>
       {strings.getButtonLabel()}
     </EuiButtonEmpty>
   );
@@ -48,7 +48,7 @@ export const ControlSettings = ({
     <Popover
       id="auto-refresh-popover"
       button={popoverButton}
-      anchorPosition="rightUp"
+      anchorPosition="downLeft"
       panelClassName="canvasControlSettings__popover"
     >
       {() => (

--- a/x-pack/legacy/plugins/canvas/public/components/workpad_header/element_menu/element_menu.scss
+++ b/x-pack/legacy/plugins/canvas/public/components/workpad_header/element_menu/element_menu.scss
@@ -1,0 +1,3 @@
+.canvasElementMenu__popoverButton {
+  margin-right: $euiSizeS;
+}

--- a/x-pack/legacy/plugins/canvas/public/components/workpad_header/element_menu/element_menu.tsx
+++ b/x-pack/legacy/plugins/canvas/public/components/workpad_header/element_menu/element_menu.tsx
@@ -171,6 +171,7 @@ export const ElementMenu: FunctionComponent<Props> = ({ elements, addElement }) 
       size="s"
       aria-label={strings.getElementMenuLabel()}
       onClick={togglePopover}
+      className="canvasElementMenu__popoverButton"
     >
       {strings.getElementMenuButtonLabel()}
     </EuiButton>
@@ -178,7 +179,7 @@ export const ElementMenu: FunctionComponent<Props> = ({ elements, addElement }) 
 
   return (
     <Fragment>
-      <Popover button={exportControl} panelPaddingSize="none">
+      <Popover button={exportControl} panelPaddingSize="none" anchorPosition="downLeft">
         {({ closePopover }: { closePopover: ClosePopoverFn }) => (
           <EuiContextMenu
             initialPanelId={0}

--- a/x-pack/legacy/plugins/canvas/public/components/workpad_header/share_menu/share_menu.tsx
+++ b/x-pack/legacy/plugins/canvas/public/components/workpad_header/share_menu/share_menu.tsx
@@ -93,7 +93,7 @@ export const ShareMenu: FunctionComponent<Props> = ({ onCopy, onExport, getExpor
   });
 
   const shareControl = (togglePopover: React.MouseEventHandler<any>) => (
-    <EuiButtonEmpty size="s" aria-label={strings.getShareWorkpadMessage()} onClick={togglePopover}>
+    <EuiButtonEmpty size="xs" aria-label={strings.getShareWorkpadMessage()} onClick={togglePopover}>
       {strings.getShareMenuButtonLabel()}
     </EuiButtonEmpty>
   );
@@ -102,7 +102,7 @@ export const ShareMenu: FunctionComponent<Props> = ({ onCopy, onExport, getExpor
 
   return (
     <div>
-      <Popover button={shareControl} panelPaddingSize="none">
+      <Popover button={shareControl} panelPaddingSize="none" anchorPosition="downLeft">
         {({ closePopover }: { closePopover: ClosePopoverFn }) => (
           <EuiContextMenu
             initialPanelId={0}

--- a/x-pack/legacy/plugins/canvas/public/components/workpad_header/view_menu/view_menu.tsx
+++ b/x-pack/legacy/plugins/canvas/public/components/workpad_header/view_menu/view_menu.tsx
@@ -86,7 +86,7 @@ export const ViewMenu: FunctionComponent<Props> = ({
   doRefresh,
 }) => {
   const viewControl = (togglePopover: React.MouseEventHandler<any>) => (
-    <EuiButtonEmpty size="s" aria-label={strings.getViewMenuLabel()} onClick={togglePopover}>
+    <EuiButtonEmpty size="xs" aria-label={strings.getViewMenuLabel()} onClick={togglePopover}>
       {strings.getViewMenuButtonLabel()}
     </EuiButtonEmpty>
   );
@@ -172,7 +172,7 @@ export const ViewMenu: FunctionComponent<Props> = ({
   });
 
   return (
-    <Popover button={viewControl} panelPaddingSize="none">
+    <Popover button={viewControl} panelPaddingSize="none" anchorPosition="downLeft">
       {({ closePopover }: { closePopover: ClosePopoverFn }) => (
         <EuiContextMenu initialPanelId={0} panels={flattenPanelTree(getPanelTree(closePopover))} />
       )}

--- a/x-pack/legacy/plugins/canvas/public/components/workpad_header/workpad_header.tsx
+++ b/x-pack/legacy/plugins/canvas/public/components/workpad_header/workpad_header.tsx
@@ -85,13 +85,13 @@ export const WorkpadHeader: FunctionComponent<Props> = ({
 
   return (
     <EuiFlexGroup
-      gutterSize="s"
+      gutterSize="none"
       alignItems="center"
       justifyContent="spaceBetween"
       className="canvasLayout__stageHeaderInner"
     >
       <EuiFlexItem grow={false}>
-        <EuiFlexGroup alignItems="center" gutterSize="xs">
+        <EuiFlexGroup alignItems="center" gutterSize="none">
           {isWriteable && (
             <EuiFlexItem grow={false}>
               <ElementMenu />

--- a/x-pack/legacy/plugins/canvas/public/style/index.scss
+++ b/x-pack/legacy/plugins/canvas/public/style/index.scss
@@ -52,6 +52,7 @@
 @import '../components/tooltip_annotation/tooltip_annotation';
 @import '../components/workpad/workpad';
 @import '../components/workpad_header/control_settings/control_settings';
+@import '../components/workpad_header/element_menu/element_menu';
 @import '../components/workpad_header/share_menu/share_menu';
 @import '../components/workpad_loader/workpad_loader';
 @import '../components/workpad_loader/workpad_dropzone/workpad_dropzone';


### PR DESCRIPTION
## Summary

- Reduced header padding to retain original height
- Set menus to open down left (align to anchor button's left edge)
- Reduced menu link font size and gutter/padding to match other Kibana app top menus (the button text however is set by EUI)
- Added padding between button and first menu link