### PR TITLE
Move FunctionGenerator component to lazy loaded bundle

### DIFF
--- a/x-pack/plugins/canvas/public/components/help_menu/help_menu.tsx
+++ b/x-pack/plugins/canvas/public/components/help_menu/help_menu.tsx
@@ -4,11 +4,19 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import React, { FC, useState } from 'react';
+import React, { FC, useState, lazy, Suspense } from 'react';
 import { EuiButtonEmpty, EuiPortal, EuiSpacer } from '@elastic/eui';
 import { ComponentStrings } from '../../../i18n';
 import { KeyboardShortcutsDoc } from '../keyboard_shortcuts_doc';
-import { FunctionReferenceGenerator } from '../function_reference_generator';
+
+let FunctionReferenceGenerator: null | React.LazyExoticComponent<any> = null;
+if (process.env.NODE_ENV === 'development') {
+  FunctionReferenceGenerator = lazy(() =>
+    import('../function_reference_generator').then((module) => ({
+      default: module.FunctionReferenceGenerator,
+    }))
+  );
+}
 
 const { HelpMenu: strings } = ComponentStrings;
 
@@ -27,19 +35,19 @@ export const HelpMenu: FC<Props> = ({ functionRegistry }) => {
     setFlyoutVisible(false);
   };
 
-  const isDevelopment = !['production', 'test'].includes(process.env.NODE_ENV);
-
   return (
     <>
       <EuiButtonEmpty size="xs" flush="left" iconType="keyboardShortcut" onClick={showFlyout}>
         {strings.getKeyboardShortcutsLinkLabel()}
       </EuiButtonEmpty>
-      {isDevelopment && (
-        <>
+
+      {FunctionReferenceGenerator ? (
+        <Suspense fallback={null}>
           <EuiSpacer size="s" />
           <FunctionReferenceGenerator functionRegistry={functionRegistry} />
-        </>
-      )}
+        </Suspense>
+      ) : null}
+
       {isFlyoutVisible && (
         <EuiPortal>
           <KeyboardShortcutsDoc onClose={hideFlyout} />


### PR DESCRIPTION
It's probably not a big deal, but I'm not sure if components in our public should be reaching into canvas_plugin_src.  Just to be safe, I pulled the function_reference_generator import into it's own import and wrap that in the env check.  

I _think_ that on a production build, the function referene will never even be imported, saving a bit of size for something unneccesary.  

