### PR TITLE
Use EuiButtonGroup for quick buttons

### DIFF
--- a/src/plugins/embeddable/public/lib/panel/panel_header/panel_actions/add_panel/add_panel_flyout.tsx
+++ b/src/plugins/embeddable/public/lib/panel/panel_header/panel_actions/add_panel/add_panel_flyout.tsx
@@ -18,15 +18,14 @@
  */
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n/react';
-import React, { ReactElement } from 'react';
+import React from 'react';
 import { CoreSetup } from 'src/core/public';
 
-import { EuiContextMenuItem, EuiFlyoutBody, EuiFlyoutHeader, EuiTitle } from '@elastic/eui';
+import { EuiFlyoutBody, EuiFlyoutHeader, EuiTitle } from '@elastic/eui';
 
 import { EmbeddableStart } from 'src/plugins/embeddable/public';
 import { IContainer } from '../../../../containers';
 import { EmbeddableFactoryNotFoundError } from '../../../../errors';
-import { SavedObjectFinderCreateNew } from './saved_object_finder_create_new';
 import { SavedObjectEmbeddableInput } from '../../../../embeddables';
 
 interface Props {
@@ -40,10 +39,6 @@ interface Props {
 
 interface State {
   isCreateMenuOpen: boolean;
-}
-
-function capitalize([first, ...letters]: string) {
-  return `${first.toUpperCase()}${letters.join('')}`;
 }
 
 export class AddPanelFlyout extends React.Component<Props, State> {

--- a/src/plugins/presentation_util/public/components/panel_toolbar/panel_toolbar.tsx
+++ b/src/plugins/presentation_util/public/components/panel_toolbar/panel_toolbar.tsx
@@ -151,7 +151,7 @@ export const PanelToolbar: FC<Props> = ({ primaryActionButton, quickButtons = []
         <EuiFlexItem grow={false}>
           <EuiFlexGroup gutterSize="none">
             <EuiButtonGroup
-              legend="Text style"
+              legend="Quick buttons"
               options={buttonGroupOptions}
               onChange={(id) => onChangeIconsMulti(id)}
               type="multi"

--- a/src/plugins/presentation_util/public/components/panel_toolbar/panel_toolbar.tsx
+++ b/src/plugins/presentation_util/public/components/panel_toolbar/panel_toolbar.tsx
@@ -27,8 +27,6 @@ import {
   EuiPopover,
   EuiContextMenu,
   IconType,
-  EuiButtonIcon,
-  EuiToolTip,
 } from '@elastic/eui';
 import { htmlIdGenerator } from '@elastic/eui';
 import { CoreStart } from 'kibana/public';
@@ -126,21 +124,18 @@ export const PanelToolbar: FC<Props> = ({ primaryActionButton, quickButtons = []
     </EuiButton>
   );
 
-  const buttonGroupOptions = [];
-
-  quickButtons.map(({ iconType, tooltip, action }: QuickButtons, index) => {
-    const quickButton = {
+  const buttonGroupOptions = quickButtons.map(
+    ({ iconType, tooltip, action }: QuickButtons, index) => ({
       iconType,
       action,
       id: `${htmlIdGenerator()()}${index}`,
       label: tooltip,
-    };
-    quickButton['aria-label'] = `Create new ${tooltip}`;
-    buttonGroupOptions.push(quickButton);
-  });
+      'aria-label': `Create new ${tooltip}`,
+    })
+  );
 
-  const onChangeIconsMulti = (optionId) => {
-    buttonGroupOptions.find((x) => x.id === optionId).action();
+  const onChangeIconsMulti = (optionId: string) => {
+    buttonGroupOptions.find((x) => x.id === optionId)?.action();
   };
 
   return (
@@ -152,7 +147,7 @@ export const PanelToolbar: FC<Props> = ({ primaryActionButton, quickButtons = []
             <EuiButtonGroup
               legend="Quick buttons"
               options={buttonGroupOptions}
-              onChange={(id) => onChangeIconsMulti(id)}
+              onChange={onChangeIconsMulti}
               type="multi"
               isIconOnly
             />

--- a/src/plugins/presentation_util/public/components/panel_toolbar/panel_toolbar.tsx
+++ b/src/plugins/presentation_util/public/components/panel_toolbar/panel_toolbar.tsx
@@ -21,6 +21,7 @@ import './panel_toolbar.scss';
 import React, { FC, useState, useCallback } from 'react';
 import {
   EuiButton,
+  EuiButtonGroup,
   EuiFlexGroup,
   EuiFlexItem,
   EuiPopover,
@@ -29,6 +30,7 @@ import {
   EuiButtonIcon,
   EuiToolTip,
 } from '@elastic/eui';
+import { htmlIdGenerator } from '@elastic/eui';
 import { CoreStart } from 'kibana/public';
 import { useKibana } from '../../../../kibana_react/public';
 import {
@@ -124,24 +126,37 @@ export const PanelToolbar: FC<Props> = ({ primaryActionButton, quickButtons = []
     </EuiButton>
   );
 
+  const buttonGroupOptions = [];
+
+  quickButtons.map(({ iconType, tooltip, action }: QuickButtons, index) => {
+    const quickButton = {
+      iconType,
+      action,
+      className: 'panelToolbarButton',
+      id: `${htmlIdGenerator()()}${index}`,
+      label: tooltip,
+    };
+    quickButton['aria-label'] = `Create new ${tooltip}`;
+    buttonGroupOptions.push(quickButton);
+  });
+
+  const onChangeIconsMulti = (optionId) => {
+    buttonGroupOptions.find((x) => x.id === optionId).action();
+  };
+
   return (
     <EuiFlexGroup className="panelToolbar" id="kbnPresentationToolbar__panelToolbar" gutterSize="s">
       <EuiFlexItem grow={false}>{primaryActionButton}</EuiFlexItem>
       {quickButtons.length ? (
         <EuiFlexItem grow={false}>
           <EuiFlexGroup gutterSize="none">
-            {quickButtons.map(({ iconType, tooltip, action }: QuickButtons) => (
-              <EuiFlexItem id={tooltip}>
-                <EuiToolTip content={tooltip}>
-                  <EuiButtonIcon
-                    className="panelToolbarButton"
-                    iconType={iconType}
-                    onClick={action}
-                    aria-label={`Create new ${tooltip}`}
-                  />
-                </EuiToolTip>
-              </EuiFlexItem>
-            ))}
+            <EuiButtonGroup
+              legend="Text style"
+              options={buttonGroupOptions}
+              onChange={(id) => onChangeIconsMulti(id)}
+              type="multi"
+              isIconOnly
+            />
           </EuiFlexGroup>
         </EuiFlexItem>
       ) : null}

--- a/src/plugins/presentation_util/public/components/panel_toolbar/panel_toolbar.tsx
+++ b/src/plugins/presentation_util/public/components/panel_toolbar/panel_toolbar.tsx
@@ -132,7 +132,6 @@ export const PanelToolbar: FC<Props> = ({ primaryActionButton, quickButtons = []
     const quickButton = {
       iconType,
       action,
-      className: 'panelToolbarButton',
       id: `${htmlIdGenerator()()}${index}`,
       label: tooltip,
     };

--- a/src/plugins/visualizations/public/embeddable/visualize_embeddable_factory.tsx
+++ b/src/plugins/visualizations/public/embeddable/visualize_embeddable_factory.tsx
@@ -38,7 +38,7 @@ import {
   VisualizeSavedObjectAttributes,
 } from './visualize_embeddable';
 import { VISUALIZE_EMBEDDABLE_TYPE } from './constants';
-import { SerializedVis, Vis } from '../vis';
+import { Vis } from '../vis';
 import {
   getCapabilities,
   getTypes,

--- a/src/plugins/visualizations/public/wizard/new_vis_modal.tsx
+++ b/src/plugins/visualizations/public/wizard/new_vis_modal.tsx
@@ -97,8 +97,14 @@ class NewVisModal extends React.Component<TypeSelectionProps, TypeSelectionState
     }
 
     if (this.props.visType) {
-      this.onVisTypeSelected(this.props.visTypesRegistry.get(this.props.visType));
-      return null;
+      const visType =
+        this.props.visTypesRegistry.get(this.props.visType) ||
+        this.props.visTypesRegistry.getAliases().find((alias) => this.props.visType === alias.name);
+
+      if (visType) {
+        this.onVisTypeSelected(visType);
+        return null;
+      }
     }
 
     const visNewVisDialogAriaLabel = i18n.translate(


### PR DESCRIPTION
## Summary

- Added `EuiButtonGroup` for quick buttons.
- In follow-up PR we can aim to build a reusable component for these buttons to reuse the existing code in Lens.

@cqliu1 there seem to be a few TS complaints, can you please take a look?

<img width="1440" alt="image 4" src="https://user-images.githubusercontent.com/4016496/104251944-dc8f0c80-543e-11eb-8327-05eec998e73e.png">

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
