### PR TITLE
[Controls] Design pass for range slider control

### DIFF
--- a/src/plugins/controls/public/control_types/range_slider/range_slider.scss
+++ b/src/plugins/controls/public/control_types/range_slider/range_slider.scss
@@ -1,37 +1,36 @@
-.rangeSlider__anchorOverride {
-  display:block;
-}
-
 .rangeSlider__popoverOverride {
-  width: 100%;
   height: 100%;
 }
 
-.rangeSlider__popoverAnchorButton {
-  width:100%;
-}
-
-.rangeSlider__actions {
-  padding: $euiSizeS;
-  border-bottom: $euiBorderThin;
-  border-color: darken($euiColorLightestShade, 2%);
-}
-
-.rangeSlider--filterGroup {
-  width: 100%;
-}
-
-.customButton {
-  background-color: #fbfcfd;
-  border-radius: 0 5px 5px 0;
+.rangeSliderAnchor__button {
+  display: flex;
+  align-items: center;
   width: 100%;
   height: 100%;
-  .customButton__delimiter {
-    background-color: lightblue !important;
+  justify-content: space-between;
+  background-color: $euiFormBackgroundColor;
+  @include euiFormControlSideBorderRadius($euiFormControlBorderRadius, $side: 'right', $internal: true);
+
+  .rangeSliderAnchor__delimiter {
+    background-color: unset;
   }
-  .euiFieldNumber {
+  .rangeSliderAnchor__fieldNumber {
+    font-weight: $euiFontWeightBold;
     box-shadow: none;
-    background-color: transparent;
     text-align: center;
+    background-color: unset;
+
+    // Hide arrows from input number
+    &::-webkit-outer-spin-button,
+    &::-webkit-inner-spin-button {
+      -webkit-appearance: none;
+    }
+    &[type=number] {
+      -moz-appearance: textfield;
+    }
+  }
+
+  .rangeSliderAnchor__spinner {
+    padding-right: $euiSizeS;
   }
 }

--- a/src/plugins/controls/public/control_types/range_slider/range_slider.scss
+++ b/src/plugins/controls/public/control_types/range_slider/range_slider.scss
@@ -20,3 +20,20 @@
 .rangeSlider--filterGroup {
   width: 100%;
 }
+
+.customButton {
+  background-color: #fbfcfd;
+  border-radius: 0 5px 5px 0;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  .customButton__delimiter {
+    background-color: lightblue !important;
+  }
+  .euiFieldNumber {
+    box-shadow: none;
+    background-color: transparent;
+    text-align: center;
+  }
+}

--- a/src/plugins/controls/public/control_types/range_slider/range_slider.scss
+++ b/src/plugins/controls/public/control_types/range_slider/range_slider.scss
@@ -24,8 +24,6 @@
 .customButton {
   background-color: #fbfcfd;
   border-radius: 0 5px 5px 0;
-  display: flex;
-  align-items: center;
   width: 100%;
   height: 100%;
   .customButton__delimiter {

--- a/src/plugins/controls/public/control_types/range_slider/range_slider_popover.tsx
+++ b/src/plugins/controls/public/control_types/range_slider/range_slider_popover.tsx
@@ -7,7 +7,14 @@
  */
 
 import React, { FC, useState } from 'react';
-import { EuiFieldNumber, EuiPopover, EuiPopoverTitle, EuiText } from '@elastic/eui';
+import {
+  EuiFlexItem,
+  EuiFlexGroup,
+  EuiFieldNumber,
+  EuiPopover,
+  EuiPopoverTitle,
+  EuiText,
+} from '@elastic/eui';
 import { ValidatedDualRange } from '../../../../kibana_react/public';
 
 import { RangeValue } from './types';
@@ -42,11 +49,19 @@ export const RangeSliderPopover: FC<Props> = ({
 
   const button = (
     <button onClick={() => setIsPopoverOpen((openState) => !openState)} className="customButton">
-      <EuiFieldNumber readOnly value={min} />
-      <EuiText className="customButton__delimeter" size="s" color="subdued">
-        →
-      </EuiText>
-      <EuiFieldNumber readOnly value={max} />
+      <EuiFlexGroup responsive={false} gutterSize="none">
+        <EuiFlexItem>
+          <EuiFieldNumber readOnly value={min} />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiText className="customButton__delimeter" size="s" color="subdued">
+            →
+          </EuiText>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiFieldNumber readOnly value={max} />
+        </EuiFlexItem>
+      </EuiFlexGroup>
     </button>
     // className="rangeSlider__popoverAnchorButton"
     // data-test-subj={`range-slider-control-${id}`}

--- a/src/plugins/controls/public/control_types/range_slider/range_slider_popover.tsx
+++ b/src/plugins/controls/public/control_types/range_slider/range_slider_popover.tsx
@@ -7,7 +7,7 @@
  */
 
 import React, { FC, useState } from 'react';
-import { EuiFilterButton, EuiDualRange, EuiPopover, EuiPopoverTitle } from '@elastic/eui';
+import { EuiFieldNumber, EuiPopover, EuiPopoverTitle, EuiText } from '@elastic/eui';
 import { ValidatedDualRange } from '../../../../kibana_react/public';
 
 import { RangeValue } from './types';
@@ -41,14 +41,19 @@ export const RangeSliderPopover: FC<Props> = ({
   ];
 
   const button = (
-    <EuiFilterButton
-      className="rangeSlider__popoverAnchorButton"
-      data-test-subj={`range-slider-control-${id}`}
-      onClick={() => setIsPopoverOpen((openState) => !openState)}
-      isLoading={isLoading}
-      isSelected={isPopoverOpen}
-    >
-      <EuiDualRange
+    <button onClick={() => setIsPopoverOpen((openState) => !openState)} className="customButton">
+      <EuiFieldNumber readOnly value={min} />
+      <EuiText className="customButton__delimeter" size="s" color="subdued">
+        →
+      </EuiText>
+      <EuiFieldNumber readOnly value={max} />
+    </button>
+    // className="rangeSlider__popoverAnchorButton"
+    // data-test-subj={`range-slider-control-${id}`}
+    // onClick={() => setIsPopoverOpen((openState) => !openState)}
+    // isLoading={isLoading}
+    // isSelected={isPopoverOpen}
+    /* <EuiDualRange
         min={min}
         max={max}
         value={value}
@@ -56,8 +61,7 @@ export const RangeSliderPopover: FC<Props> = ({
         fullWidth
         readOnly
         onChange={() => {}}
-      />
-    </EuiFilterButton>
+      /> */
   );
 
   return (

--- a/src/plugins/controls/public/control_types/range_slider/range_slider_popover.tsx
+++ b/src/plugins/controls/public/control_types/range_slider/range_slider_popover.tsx
@@ -14,6 +14,7 @@ import {
   EuiPopover,
   EuiPopoverTitle,
   EuiText,
+  EuiLoadingSpinner,
 } from '@elastic/eui';
 import { ValidatedDualRange } from '../../../../kibana_react/public';
 
@@ -48,45 +49,33 @@ export const RangeSliderPopover: FC<Props> = ({
   ];
 
   const button = (
-    <button onClick={() => setIsPopoverOpen((openState) => !openState)} className="customButton">
-      <EuiFlexGroup responsive={false} gutterSize="none">
-        <EuiFlexItem>
-          <EuiFieldNumber readOnly value={min} />
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiText className="customButton__delimeter" size="s" color="subdued">
-            →
-          </EuiText>
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiFieldNumber readOnly value={max} />
-        </EuiFlexItem>
-      </EuiFlexGroup>
+    <button
+      onClick={() => setIsPopoverOpen((openState) => !openState)}
+      className="rangeSliderAnchor__button"
+      data-test-subj={`range-slider-control-${id}`}
+    >
+      <EuiFieldNumber controlOnly className="rangeSliderAnchor__fieldNumber" readOnly value={min} />
+      <EuiText className="rangeSliderAnchor__delimiter" size="s" color="subdued">
+        →
+      </EuiText>
+      <EuiFieldNumber controlOnly className="rangeSliderAnchor__fieldNumber" readOnly value={max} />
+      {isLoading ? (
+        <div className="rangeSliderAnchor__spinner">
+          <EuiLoadingSpinner />
+        </div>
+      ) : undefined}
     </button>
-    // className="rangeSlider__popoverAnchorButton"
-    // data-test-subj={`range-slider-control-${id}`}
-    // onClick={() => setIsPopoverOpen((openState) => !openState)}
-    // isLoading={isLoading}
-    // isSelected={isPopoverOpen}
-    /* <EuiDualRange
-        min={min}
-        max={max}
-        value={value}
-        showInput="inputWithPopover"
-        fullWidth
-        readOnly
-        onChange={() => {}}
-      /> */
   );
 
   return (
     <EuiPopover
       button={button}
       isOpen={isPopoverOpen}
+      display="block"
+      panelPaddingSize="s"
       className="rangeSlider__popoverOverride"
       anchorClassName="rangeSlider__anchorOverride"
       closePopover={() => setIsPopoverOpen(false)}
-      panelPaddingSize="none"
       anchorPosition="downCenter"
       ownFocus
       repositionOnScroll


### PR DESCRIPTION
## Summary

-  Added a custom implementation of the read-only portion of the control (anchor) using EUI components (namely **EuiFieldNumber**). This replaces the previous **EuiDualRange** which is a bit overkill for this use case.

<img width="1268" alt="image 10" src="https://user-images.githubusercontent.com/4016496/155255824-e9534a31-e966-45a3-8948-e4a8328cc10b.png">

@cqliu1 Note: Selecting values in the popover is not changing the values in the anchor, we probably need to hook something up.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
